### PR TITLE
Vcf post

### DIFF
--- a/cgg.py
+++ b/cgg.py
@@ -72,9 +72,9 @@ class cggPatient:
                                 params={'accessionNumber' : self.accession_number},
                                 headers = {'Authorization' : self.token})
         patient_list = json.loads(response.text) # List of dict entries FIXME ??
-	if patient_list:
-		return patient_list[0]
-	return None
+        if patient_list:
+            return patient_list[0]
+        return None
         
     def exists(self):
         """Return patient entry exists."""
@@ -161,10 +161,10 @@ def main():
     if token:
 	
 	#Parameters required for 1-creating patient, 2-uploading VCF file and 3-linking patient and VCF file.
-        accession_number = "test-patient_220221_3" #SLIMS: Sctx.sample_name
+        accession_number = "test-patient_220223_1" #SLIMS: Sctx.sample_name
         folder_name = "Default" #SLIMS: department_translate[Sctx.slims_info['department']], default: "Default"
-        patient_sex = "FEMALE" #SLIMS: Sctx.slims_info['gender'], default: "UNKNOWN"
-        path = '/home/xbregw/Alissa_upload/VCFs/known_variants_220221_2.vcf.gz' #SLIMS: Sctx.snv_cnv_vcf_path
+        patient_sex = "MALE" #SLIMS: Sctx.slims_info['gender'], default: "UNKNOWN"
+        path = '/home/xbregw/Alissa_upload/VCFs/known_variants_220223.vcf.gz' #SLIMS: Sctx.snv_cnv_vcf_path
         name_in_vcf = "NA12878" #That is the sample ID in the VCF header row. In WOPR, it should be the same as Sctx.sample_name
 
         #Check whether a patient exists, if not: create it. In both cases: return internal patient id.


### PR DESCRIPTION
In this PR, several functions were added, to: check whether a data file (VCF) exists in Alissa; upload a VCF to Alissa; and link data file to patient. The logic of the main() function was expanded to take into account cases where a patient or a data file already exist. The cggPatient class was simplified (a redundant attribute was removed).

The code can be tested as follow:
```
module load anaconda2
source activate wopr_alissa
python cgg.py
```
Note that the parameters are defined in the main() function, and thus if you do not modify them, running this will tell you that the patient and data file already exist, and you will also get an error message because the lab result exists. If you want, replace the patient name, path to the VCF, and name of the individual in the VCF header row, in main(). Note! VCF should be less than 250M, the logic to create VCF chunks is not part of `cgg.py` yet.

Please test and comment on the existing logic. I am thinking about e.g. creating a data file class with the new functions, but I am wondering whether you would like additional functionalities.